### PR TITLE
added indices to string.format fields for Python 2.6.x compatibility

### DIFF
--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -21,11 +21,11 @@ class FHIRAuth(object):
         """ Register this class to handle authorization types of the given
         type. """
         if not cls.auth_type:
-            raise Exception('Class {} does not specify the auth_type it supports'.format(cls))
+            raise Exception('Class {0} does not specify the auth_type it supports'.format(cls))
         if cls.auth_type not in FHIRAuth.auth_classes:
             FHIRAuth.auth_classes[cls.auth_type] = cls
         elif FHIRAuth.auth_classes[cls.auth_type] != cls:
-            raise Exception('Class {} is already registered for authorization type "{}"'.format(FHIRAuth.auth_classes[cls.auth_type], cls.auth_type))
+            raise Exception('Class {0} is already registered for authorization type "{1}"'.format(FHIRAuth.auth_classes[cls.auth_type], cls.auth_type))
     
     @classmethod
     def from_conformance_security(cls, security, state=None):
@@ -75,7 +75,7 @@ class FHIRAuth(object):
         if auth_type in FHIRAuth.auth_classes:
             klass = FHIRAuth.auth_classes[auth_type]
             return klass(state=state)
-        raise Exception('No class registered for authorization type "{}"'.format(auth_type))
+        raise Exception('No class registered for authorization type "{0}"'.format(auth_type))
     
     
     def __init__(self, state=None):
@@ -101,7 +101,7 @@ class FHIRAuth(object):
     
     def handle_callback(self, url, server):
         """ Return the launch context. """
-        raise Exception("{} cannot handle callback URL".format(self))
+        raise Exception("{0} cannot handle callback URL".format(self))
     
     def reauthorize(self):
         """ Perform a re-authorization of some form.
@@ -168,7 +168,7 @@ class FHIROAuth2Auth(FHIRAuth):
         
         if headers is None:
             headers = {}
-        headers['Authorization'] = "Bearer {}".format(self.access_token)
+        headers['Authorization'] = "Bearer {0}".format(self.access_token)
         
         return headers
     
@@ -181,7 +181,7 @@ class FHIROAuth2Auth(FHIRAuth):
         stored.
         """
         auth_params = self._authorize_params(server)
-        logging.debug("SMART AUTH: Will use parameters for `authorize_uri`: {}".format(auth_params))
+        logging.debug("SMART AUTH: Will use parameters for `authorize_uri`: {0}".format(auth_params))
         
         # the authorize uri may have params, make sure to not lose them
         parts = list(urlparse.urlsplit(self._authorize_uri))
@@ -228,7 +228,7 @@ class FHIROAuth2Auth(FHIRAuth):
         try:
             args = dict(urlparse.parse_qsl(urlparse.urlsplit(url)[3]))
         except Exception as e:
-            raise Exception("Invalid callback URL: {}".format(e))
+            raise Exception("Invalid callback URL: {0}".format(e))
         
         # verify response
         err = self.extract_oauth_error(args)
@@ -237,11 +237,11 @@ class FHIROAuth2Auth(FHIRAuth):
         
         stt = args.get('state')
         if stt is None or self.auth_state != stt:
-            raise Exception("Invalid state, will not use this code. Have: {}, want: {}".format(stt, self.auth_state))
+            raise Exception("Invalid state, will not use this code. Have: {0}, want: {1}".format(stt, self.auth_state))
         
         code = args.get('code')
         if code is None:
-            raise Exception("Did not receive a code, only have: {}".format(', '.join(args.keys())))
+            raise Exception("Did not receive a code, only have: {0}".format(', '.join(args.keys())))
         
         # exchange code for token
         exchange = self._code_exchange_params(code)
@@ -269,7 +269,7 @@ class FHIROAuth2Auth(FHIRAuth):
         if server is None:
             raise Exception("I need a server to request an access token")
         
-        logging.debug("SMART AUTH: Requesting access token from {}".format(self._token_uri))
+        logging.debug("SMART AUTH: Requesting access token from {0}".format(self._token_uri))
         ret_params = server.post_as_form(self._token_uri, params).json()
         
         self.access_token = ret_params.get('access_token')
@@ -283,7 +283,7 @@ class FHIROAuth2Auth(FHIRAuth):
         if self.refresh_token is not None:
             del ret_params['refresh_token']
         
-        logging.debug("SMART AUTH: Received access token: {}, refresh token: {}"
+        logging.debug("SMART AUTH: Received access token: {0}, refresh token: {1}"
             .format(self.access_token is not None, self.refresh_token is not None))
         return ret_params
     
@@ -377,7 +377,7 @@ class FHIROAuth2Auth(FHIRAuth):
                 return "The authorization server encountered an unexpected condition that prevented it from fulfilling the request."
             if 'temporarily_unavailable' == err_code:
                 return "The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server."
-            return "Authorization error: {}.".format(err_code)
+            return "Authorization error: {0}.".format(err_code)
         
         return None
     

--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -120,9 +120,9 @@ class FHIRClient(object):
         return self.launch_context is not None
     
     def _handle_launch_context(self, ctx):
-        logging.debug("SMART: Handling launch context: {}".format(ctx))
+        logging.debug("SMART: Handling launch context: {0}".format(ctx))
         if 'patient' in ctx:
-            #print('Patient id was {}, row context is {}'.format(self.patient_id, ctx))
+            #print('Patient id was {0}, row context is {1}'.format(self.patient_id, ctx))
             self.patient_id = ctx['patient']        # TODO: TEST THIS!
         if 'id_token' in ctx:
             logging.warning("SMART: Received an id_token, ignoring")
@@ -137,15 +137,15 @@ class FHIRClient(object):
         if self._patient is None and self.patient_id is not None and self.ready:
             import models.patient
             try:
-                logging.debug("SMART: Attempting to read Patient {}".format(self.patient_id))
+                logging.debug("SMART: Attempting to read Patient {0}".format(self.patient_id))
                 self._patient = models.patient.Patient.read(self.patient_id, self.server)
             except FHIRUnauthorizedException as e:
                 if self.reauthorize():
-                    logging.debug("SMART: Attempting to read Patient {} after reauthorizing"
+                    logging.debug("SMART: Attempting to read Patient {0} after reauthorizing"
                         .format(self.patient_id))
                     self._patient = models.patient.Patient.read(self.patient_id, self.server)
             except FHIRNotFoundException as e:
-                logging.warning("SMART: Patient with id {} not found".format(self.patient_id))
+                logging.warning("SMART: Patient with id {0} not found".format(self.patient_id))
                 self.patient_id = None
             self.save_state()
         

--- a/fhirclient/models/fhirelement.py
+++ b/fhirclient/models/fhirelement.py
@@ -86,7 +86,7 @@ class FHIRElement(object):
         if jsondict is None:
             return
         if not isinstance(jsondict, dict):
-            logging.warning("Non-dict type {} fed to `update_with_json` on {}"
+            logging.warning("Non-dict type {0} fed to `update_with_json` on {1}"
                 .format(type(jsondict), type(self)))
             return
         
@@ -109,7 +109,7 @@ class FHIRElement(object):
                 if res.id:
                     self.contained[res.id] = res
                 else:
-                    logging.warning("Contained resource {} does not have an id, ignoring".format(res))
+                    logging.warning("Contained resource {0} does not have an id, ignoring".format(res))
     
     def as_json(self):
         """ Serializes to JSON by inspecting `elementProperties()` and creating

--- a/fhirclient/models/fhirreference.py
+++ b/fhirclient/models/fhirreference.py
@@ -32,7 +32,7 @@ class FHIRReference(reference.Reference):
         if resolved is not None:
             if isinstance(resolved, klass):
                 return resolved
-            logging.warning("Reference {} is not a {} but a {}".format(refid, klass, resolved.__class__))
+            logging.warning("Reference {0} is not a {1} but a {2}".format(refid, klass, resolved.__class__))
             return None
         
         # not yet resolved, see if it's a contained resource
@@ -45,14 +45,14 @@ class FHIRReference(reference.Reference):
         # fetch remote resources
         server = self._owner.server()
         if server is None:
-            logging.warning("Reference owner {} does not have a server, cannot resolve reference {}"
+            logging.warning("Reference owner {0} does not have a server, cannot resolve reference {1}"
                 .format(self._owner, self.reference))
             return None
         
         if '://' not in self.reference:
             return self._referenced_class.read_from(self.reference, server)
         
-        logging.warning("Not implemented: resolving reference to foreign resource {}"
+        logging.warning("Not implemented: resolving reference to foreign resource {0}"
             .format(self.reference))
         return None
     

--- a/fhirclient/models/fhirresource.py
+++ b/fhirclient/models/fhirresource.py
@@ -43,7 +43,7 @@ class FHIRResource(fhirelement.FHIRElement):
         return self.__class__.resource_name
     
     def relativePath(self):
-        return "{}/{}".format(self.relativeBase(), self.id)
+        return "{0}/{1}".format(self.relativeBase(), self.id)
     
     
     # MARK: Server Connection
@@ -79,7 +79,7 @@ class FHIRResource(fhirelement.FHIRElement):
         if not rem_id:
             raise Exception("Cannot read resource without remote id")
         
-        path = '{}/{}'.format(cls.resource_name, rem_id)
+        path = '{0}/{1}'.format(cls.resource_name, rem_id)
         instance = cls.read_from(path, server)
         instance._local_id = rem_id
         

--- a/fhirclient/models/fhirsearch.py
+++ b/fhirclient/models/fhirsearch.py
@@ -26,7 +26,7 @@ class FHIRSearch(object):
         
         if struct is not None:
             if dict != type(struct):
-                raise Exception("Must pass a Python dictionary, but got a {}".format(type(struct)))
+                raise Exception("Must pass a Python dictionary, but got a {0}".format(type(struct)))
             self.wants_expand = True
             for key, val in struct.items():
                 self.params.append(FHIRSearchParam(key, val))
@@ -49,7 +49,7 @@ class FHIRSearch(object):
                 else:
                     parts.append(param.as_parameter())
         
-        return '{}?{}'.format(self.resource_type.resource_name, '&'.join(parts))
+        return '{0}?{1}'.format(self.resource_type.resource_name, '&'.join(parts))
     
     def perform(self, server):
         """ Construct the search URL and execute it against the given server.
@@ -114,7 +114,7 @@ class FHIRSearchParam(object):
     def as_parameter(self):
         """ Return a string that represents the reciever as "key=value".
         """
-        return '{}={}'.format(self.name, quote_plus(self.value, safe=',<=>'))
+        return '{0}={1}'.format(self.name, quote_plus(self.value, safe=',<=>'))
 
 
 class FHIRSearchParamHandler(object):
@@ -188,7 +188,7 @@ class FHIRSearchParamHandler(object):
     
     def apply(self, param):
         if self.key is not None:
-            param.name = '{}.{}'.format(param.name, self.key)
+            param.name = '{0}.{1}'.format(param.name, self.key)
         if 0 == len(self.multiplier):
             param.value = self.value
 
@@ -206,7 +206,7 @@ class FHIRSearchParamModifierHandler(FHIRSearchParamHandler):
     
     def apply(self, param):
         if self.key not in self.__class__.modifiers:
-            raise Exception('Unknown modifier "{}" for "{}"'.format(self.key, param.name))
+            raise Exception('Unknown modifier "{0}" for "{1}"'.format(self.key, param.name))
         param.name += self.__class__.modifiers[self.key]
         param.value = self.value
 
@@ -222,7 +222,7 @@ class FHIRSearchParamOperatorHandler(FHIRSearchParamHandler):
     
     def apply(self, param):
         if self.key not in self.__class__.operators:
-            raise Exception('Unknown operator "{}" for "{}"'.format(self.key, parent.name))
+            raise Exception('Unknown operator "{0}" for "{1}"'.format(self.key, parent.name))
         param.value = self.__class__.operators[self.key] + self.value
 
 
@@ -231,7 +231,7 @@ class FHIRSearchParamMultiHandler(FHIRSearchParamHandler):
     
     def prepare(self, parent):
         if list != type(self.value):
-            raise Exception('Expecting a list argument for "{}" but got {}'.format(parent.key, self.value))
+            raise Exception('Expecting a list argument for "{0}" but got {1}'.format(parent.key, self.value))
         
         handlers = []
         for val in self.value:
@@ -249,7 +249,7 @@ class FHIRSearchParamMultiHandler(FHIRSearchParamHandler):
             handler = FHIRSearchParamHandler.handler_for(parent.key)(None, ','.join(ors))
             handler.prepare(parent)
         else:
-            raise Exception('I cannot handle "{}"'.format(self.key))
+            raise Exception('I cannot handle "{1}"'.format(self.key))
 
 
 class FHIRSearchParamTypeHandler(FHIRSearchParamHandler):
@@ -259,7 +259,7 @@ class FHIRSearchParamTypeHandler(FHIRSearchParamHandler):
         parent.modifier.append(self)
     
     def apply(self, param):
-        param.name = '{}:{}'.format(param.name, self.value)
+        param.name = '{0}:{1}'.format(param.name, self.value)
     
 
 # announce all handlers

--- a/fhirclient/server.py
+++ b/fhirclient/server.py
@@ -62,7 +62,7 @@ class FHIRServer(object):
         or forced.
         """
         if self._conformance is None or force:
-            logging.info('Fetching conformance statement from {}'.format(self.base_uri))
+            logging.info('Fetching conformance statement from {0}'.format(self.base_uri))
             from models import conformance
             conf = conformance.Conformance.read_from('metadata', self)
             self._conformance = conf

--- a/flask_app.py
+++ b/flask_app.py
@@ -64,17 +64,17 @@ def index():
         name = smart.human_name(smart.patient.name[0] if smart.patient.name and len(smart.patient.name) > 0 else 'Unknown')
         
         # generate simple body text
-        body += "<p>You are authorized and ready to make API requests for <em>{}</em>.</p>".format(name)
+        body += "<p>You are authorized and ready to make API requests for <em>{0}</em>.</p>".format(name)
         pres = _get_prescriptions(smart)
         if pres is not None:
-            body += "<p>{} prescriptions: <ul><li>{}</li></ul></p>".format("His" if 'male' == smart.patient.gender else "Her", '</li><li>'.join([_med_name(p) for p in pres]))
+            body += "<p>{0} prescriptions: <ul><li>{1}</li></ul></p>".format("His" if 'male' == smart.patient.gender else "Her", '</li><li>'.join([_med_name(p) for p in pres]))
         else:
-            body += "<p>(There are no prescriptions for {})</p>".format("him" if 'male' == smart.patient.gender else "her")
-        body += """<p><a href="/logout">Change patient</a></p>""".format(name)
+            body += "<p>(There are no prescriptions for {0})</p>".format("him" if 'male' == smart.patient.gender else "her")
+        body += """<p><a href="/logout">Change patient</a></p>"""
     else:
         auth_url = smart.authorize_url
         if auth_url is not None:
-            body += """<p>Please <a href="{}">authorize</a>.</p>""".format(auth_url)
+            body += """<p>Please <a href="{0}">authorize</a>.</p>""".format(auth_url)
         else:
             body += """<p>Running against a no-auth server, nothing to demo here. """
         body += """<p><a href="/reset" style="font-size:small;">Reset</a></p>"""
@@ -89,7 +89,7 @@ def callback():
     try:
         smart.handle_callback(request.url)
     except Exception as e:
-        return """<h1>Authorization Error</h1><p>{}</p><p><a href="/">Start over</a></p>""".format(e)
+        return """<h1>Authorization Error</h1><p>{0}</p><p><a href="/">Start over</a></p>""".format(e)
     return redirect('/')
 
 


### PR DESCRIPTION
I don't know if support for Python versions <2.7 is a priority, but we've made these small changes to simplify our workflow when deploying on RHEL 6 / CentOS 6.