### PR TITLE
Add support for confidential clients

### DIFF
--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -20,6 +20,7 @@ class FHIRClient(object):
     The settings dictionary supports:
     
         - `app_id`*: Your app/client-id, e.g. 'my_web_app'
+        - `app_secret`*: Your app/client-secret
         - `api_base`*: The FHIR service to connect to, e.g. 'https://fhir-api-dstu2.smarthealthit.org'
         - `redirect_uri`: The callback/redirect URL for your app, e.g. 'http://localhost:8000/fhir-app/' when testing locally
         - `patient_id`: The patient id against which to operate, if already known
@@ -29,6 +30,7 @@ class FHIRClient(object):
     
     def __init__(self, settings=None, state=None, save_func=lambda x:x):
         self.app_id = None
+        self.app_secret = None
         """ The app-id for the app this client is used in. """
         
         self.server = None
@@ -65,6 +67,7 @@ class FHIRClient(object):
                 raise Exception("Must provide 'api_base' in settings dictionary")
             
             self.app_id = settings['app_id']
+            self.app_secret = settings.get('app_secret')
             self.redirect = settings.get('redirect_uri')
             self.patient_id = settings.get('patient_id')
             self.scope = settings.get('scope', self.scope)
@@ -194,6 +197,7 @@ class FHIRClient(object):
     def state(self):
         return {
             'app_id': self.app_id,
+            'app_secret': self.app_secret,
             'scope': self.scope,
             'redirect': self.redirect,
             'patient_id': self.patient_id,
@@ -205,6 +209,7 @@ class FHIRClient(object):
     def from_state(self, state):
         assert state
         self.app_id = state.get('app_id') or self.app_id
+        self.app_secret = state.get('app_secret') or self.app_secret
         self.scope = state.get('scope') or self.scope
         self.redirect = state.get('redirect') or self.redirect
         self.patient_id = state.get('patient_id') or self.patient_id

--- a/fhirclient/server.py
+++ b/fhirclient/server.py
@@ -229,7 +229,14 @@ class FHIRServer(object):
             'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
             'Accept': 'application/json',
         }
-        res = requests.post(url, data=formdata)
+        if self.client.app_secret:
+            auth = requests.auth.HTTPBasicAuth(
+                self.client.app_id,
+                self.client.app_secret,
+            )
+            res = requests.post(url, data=formdata, auth=auth)
+        else:
+            res = requests.post(url, data=formdata)
         self.raise_for_status(res)
         return res
     


### PR DESCRIPTION
This adds support for confidential apps as described in http://docs.smarthealthit.org/authorization/#app-exchanges-authorization-code-for-access-token.

I'm sorry about all the extra whitespace changes, my vim is set to automatically delete trailing whitespace on save. If this is an issue, I can figure out how to put them all back.