### PR TITLE
Add include method to FHIRSearch objects

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,6 +9,7 @@ Contributors
 
 The following wonderful people contributed directly or indirectly to this project:
 
+- Andrew Bjonnes <https://github.com/abjonnes>
 - Erik Wiffin <https://github.com/erikwiffin>
 - Josh Mandel <https://github.com/jmandel>
 - Nikolai Schwertner <https://github.com/nschwertner>

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ for procedure in procedures:
     procedure.as_json()
     # {'status': u'completed', 'code': {'text': u'Lumpectomy w/ SN', ...
 
+# to include the resources referred to by the procedure via `subject` in the results
+search = search.include('subject')
+
+# to include the MedicationAdministration resources which refer to the procedure via `partOf`
+import fhirclient.models.medicationadministration as m
+search = search.include('partOf', m.MedicationAdministration, reverse=True)
+
 # to get the raw Bundle instead of resources only, you can use:
 bundle = search.perform(smart.server)
 ```


### PR DESCRIPTION
This adds the ability to use `_include` and `_revinclude` with FHIRSearch objects (#13). It supports only simple forward or reverse includes - no recursive or iterative includes.

Also fixes a small typo in FHIRSearch (#35)!