### PR TITLE
Alter field requirements

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,6 +10,7 @@ Contributors
 The following wonderful people contributed directly or indirectly to this project:
 
 - Erik Wiffin <https://github.com/erikwiffin>
+- Jane Williams <https://github.com/jane-williams>
 - Josh Mandel <https://github.com/jmandel>
 - Nikolai Schwertner <https://github.com/nschwertner>
 - Pascal Pfiffner <https://github.com/p2>

--- a/fhirclient/models/explanationofbenefit.py
+++ b/fhirclient/models/explanationofbenefit.py
@@ -622,10 +622,10 @@ class ExplanationOfBenefitDiagnosis(backboneelement.BackboneElement):
     def elementProperties(self):
         js = super(ExplanationOfBenefitDiagnosis, self).elementProperties()
         js.extend([
-            ("diagnosisCodeableConcept", "diagnosisCodeableConcept", codeableconcept.CodeableConcept, False, "diagnosis", True),
-            ("diagnosisReference", "diagnosisReference", fhirreference.FHIRReference, False, "diagnosis", True),
+            ("diagnosisCodeableConcept", "diagnosisCodeableConcept", codeableconcept.CodeableConcept, False, "diagnosis", False),
+            ("diagnosisReference", "diagnosisReference", fhirreference.FHIRReference, False, "diagnosis", False),
             ("packageCode", "packageCode", codeableconcept.CodeableConcept, False, None, False),
-            ("sequence", "sequence", int, False, None, True),
+            ("sequence", "sequence", int, False, None, False),
             ("type", "type", codeableconcept.CodeableConcept, True, None, False),
         ])
         return js
@@ -1034,7 +1034,7 @@ class ExplanationOfBenefitItemDetail(backboneelement.BackboneElement):
             ("programCode", "programCode", codeableconcept.CodeableConcept, True, None, False),
             ("quantity", "quantity", quantity.Quantity, False, None, False),
             ("revenue", "revenue", codeableconcept.CodeableConcept, False, None, False),
-            ("sequence", "sequence", int, False, None, True),
+            ("sequence", "sequence", int, False, None, False),
             ("service", "service", codeableconcept.CodeableConcept, False, None, False),
             ("subDetail", "subDetail", ExplanationOfBenefitItemDetailSubDetail, True, None, False),
             ("type", "type", codeableconcept.CodeableConcept, False, None, True),

--- a/fhirclient/models/referralrequest.py
+++ b/fhirclient/models/referralrequest.py
@@ -136,7 +136,7 @@ class ReferralRequest(domainresource.DomainResource):
             ("description", "description", str, False, None, False),
             ("groupIdentifier", "groupIdentifier", identifier.Identifier, False, None, False),
             ("identifier", "identifier", identifier.Identifier, True, None, False),
-            ("intent", "intent", str, False, None, True),
+            ("intent", "intent", str, False, None, False),
             ("note", "note", annotation.Annotation, True, None, False),
             ("occurrenceDateTime", "occurrenceDateTime", fhirdate.FHIRDate, False, "occurrence", False),
             ("occurrencePeriod", "occurrencePeriod", period.Period, False, "occurrence", False),


### PR DESCRIPTION
At Clover Health (https://www.cloverhealth.com/), we have been using this library to interact with the FHIR data returned from CMS' Blue Button API (https://bluebutton.cms.gov/developers/). While testing against CMS Blue Button Sandbox API, we found a handful of cases where fields set to `"not-optional"` were not included in the FHIR data coming from CMS. This PR flips those fields to `"optional"` so that the CMS FHIR data can be processed using this library.

Of course, this leads to the question of: where are are the required/non-required specifications coming from? Is the data coming from Blue Button API violating a documented contract?