### PR TITLE
Use a full UUID4 for the state param

### DIFF
--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -200,7 +200,7 @@ class FHIROAuth2Auth(FHIRAuth):
         if server is None:
             raise Exception("Cannot create an authorize-uri without server instance")
         if self.auth_state is None:
-            self.auth_state = uuid.uuid4().hex[:24]
+            self.auth_state = str(uuid.uuid4())
             server.should_save_state()
         
         params = {

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -200,7 +200,7 @@ class FHIROAuth2Auth(FHIRAuth):
         if server is None:
             raise Exception("Cannot create an authorize-uri without server instance")
         if self.auth_state is None:
-            self.auth_state = str(uuid.uuid4())[:8]
+            self.auth_state = uuid.uuid4().hex[:24]
             server.should_save_state()
         
         params = {


### PR DESCRIPTION
According to the [hl7 SMART App Launch Implementation Guide](http://www.hl7.org/fhir/smart-app-launch/#step-1-app-asks-for-authorization):

>The app SHALL use an unpredictable value for the state parameter with at least 122 bits of entropy

The current state param used by this client is only 8 characters and, according to [this](https://en.wikipedia.org/wiki/Password_strength#Entropy_as_a_measure_of_password_strength) entropy calculation, has only 41 bits of entropy.

The SMART App Launch Implementation Guide suggests using a "properly configured random uuid", which the [uuid wiki](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) indicates gives us the requisite 122 bits.

I'd like to have this in the 3.0 (STU3) version of the client, and also to merge it forward to master (R4). 