### PR TITLE
Fix create() method for Bundle type transaction/batch

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,13 +9,16 @@ Contributors
 
 The following wonderful people contributed directly or indirectly to this project:
 
+- Alexandru Stanciu <https://github.com/ducu>
 - Andrew Bjonnes <https://github.com/abjonnes>
+- Armaghan Behlum <https://github.com/armaghan-behlum>
 - Erik Wiffin <https://github.com/erikwiffin>
 - Josh Mandel <https://github.com/jmandel>
 - Martin Burchell <https://github.com/martinburchell>
 - Nikolai Schwertner <https://github.com/nschwertner>
 - Pascal Pfiffner <https://github.com/p2>
 - Raheel Sayeed <https://github.com/raheelsayeed>
+- Tim Harsch <https://github.com/timharsch>
 - Trinadh Baranika <https://github.com/bktrinadh>
 
 Please add yourself here alphabetically when you submit your first pull request.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,9 +12,10 @@ The following wonderful people contributed directly or indirectly to this projec
 - Andrew Bjonnes <https://github.com/abjonnes>
 - Erik Wiffin <https://github.com/erikwiffin>
 - Josh Mandel <https://github.com/jmandel>
+- Martin Burchell <https://github.com/martinburchell>
 - Nikolai Schwertner <https://github.com/nschwertner>
 - Pascal Pfiffner <https://github.com/p2>
-- Raheel Sayeed <https://github.com/raheelsayeed> 
+- Raheel Sayeed <https://github.com/raheelsayeed>
 - Trinadh Baranika <https://github.com/bktrinadh>
 
 Please add yourself here alphabetically when you submit your first pull request.

--- a/fhir-parser-resources/fhirabstractresource.py
+++ b/fhir-parser-resources/fhirabstractresource.py
@@ -11,19 +11,19 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
     """ Extends the FHIRAbstractBase with server talking capabilities.
     """
     resource_type = 'FHIRAbstractResource'
-
+    
     def __init__(self, jsondict=None, strict=True):
         self._server = None
         """ The server the instance was read from. """
-
+        
         # raise if "resourceType" does not match
         if jsondict is not None and 'resourceType' in jsondict \
             and jsondict['resourceType'] != self.resource_type:
             raise Exception("Attempting to instantiate {} with resource data that defines a resourceType of \"{}\""
                 .format(self.__class__, jsondict['resourceType']))
-
+        
         super(FHIRAbstractResource, self).__init__(jsondict=jsondict, strict=strict)
-
+    
     @classmethod
     def _with_json_dict(cls, jsondict):
         """ Overridden to use a factory if called when "resourceType" is
@@ -32,31 +32,31 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if not isinstance(jsondict, dict):
             raise Exception("Cannot use this method with anything but a JSON dictionary, got {}"
                 .format(jsondict))
-
+        
         res_type = jsondict.get('resourceType')
         if res_type and res_type != cls.resource_type:
             return fhirelementfactory.FHIRElementFactory.instantiate(res_type, jsondict)
         return super(FHIRAbstractResource, cls)._with_json_dict(jsondict)
-
+    
     def as_json(self):
         js = super(FHIRAbstractResource, self).as_json()
         js['resourceType'] = self.resource_type
         return js
-
-
+    
+    
     # MARK: Handling Paths
-
+    
     def relativeBase(self):
         return self.__class__.resource_type
-
+    
     def relativePath(self):
         if self.id is None:
             return self.relativeBase()
         return "{}/{}".format(self.relativeBase(), self.id)
-
-
+    
+    
     # MARK: - Server Connection
-
+    
     @property
     def origin_server(self):
         """ Walks the owner hierarchy until it finds an owner with a server.
@@ -72,31 +72,31 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
     def origin_server(self, server):
         """ Sets the server on an element. """
         self._server = server
-
+    
     @classmethod
     def read(cls, rem_id, server):
         """ Read the resource with the given id from the given server. The
         passed-in server instance must support a `request_json()` method call,
         taking a relative path as first (and only mandatory) argument.
-
+        
         :param str rem_id: The id of the resource on the remote server
         :param FHIRServer server: An instance of a FHIR server or compatible class
         :returns: An instance of the receiving class
         """
         if not rem_id:
             raise Exception("Cannot read resource without remote id")
-
+        
         path = '{}/{}'.format(cls.resource_type, rem_id)
         instance = cls.read_from(path, server)
         instance._local_id = rem_id
-
+        
         return instance
-
+    
     @classmethod
     def read_from(cls, path, server):
         """ Requests data from the given REST path on the server and creates
         an instance of the receiving class.
-
+        
         :param str path: The REST path to read from
         :param FHIRServer server: An instance of a FHIR server or compatible class
         :returns: An instance of the receiving class
@@ -105,7 +105,7 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot read resource without REST path")
         if server is None:
             raise Exception("Cannot read resource without server instance")
-
+        
         ret = server.request_json(path)
         instance = cls(jsondict=ret)
         instance.origin_server = server
@@ -126,7 +126,7 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
     def create(self, server):
         """ Attempt to create the receiver on the given server, using a POST
         command.
-
+        
         :param FHIRServer server: The server to create the receiver on
         :returns: None or the response JSON on success
         """
@@ -140,11 +140,11 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if len(ret.text) > 0:
             return ret.json()
         return None
-
+    
     def update(self, server=None):
         """ Update the receiver's representation on the given server, issuing
         a PUT command.
-
+        
         :param FHIRServer server: The server to update the receiver on;
             optional, will use the instance's `server` if needed.
         :returns: None or the response JSON on success
@@ -154,15 +154,15 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot update a resource that does not have a server")
         if not self.id:
             raise Exception("Cannot update a resource that does not have an id")
-
+        
         ret = srv.put_json(self.relativePath(), self.as_json())
         if len(ret.text) > 0:
             return ret.json()
         return None
-
+    
     def delete(self, server=None):
         """ Delete the receiver from the given server with a DELETE command.
-
+        
         :param FHIRServer server: The server to update the receiver on;
             optional, will use the instance's `server` if needed.
         :returns: None or the response JSON on success
@@ -172,22 +172,22 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot delete a resource that does not have a server")
         if not self.id:
             raise Exception("Cannot delete a resource that does not have an id")
-
+        
         ret = srv.delete_json(self.relativePath())
         if len(ret.text) > 0:
             return ret.json()
         return None
-
-
+    
+    
     # MARK: - Search
-
+    
     def search(self, struct=None):
         """ Search can be started via a dictionary containing a search
         construct.
-
+        
         Calling this method with a search struct will return a `FHIRSearch`
         object representing the search struct, with "$type" and "id" added.
-
+        
         :param dict struct: An optional search structure
         :returns: A FHIRSearch instance
         """
@@ -196,15 +196,15 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if self._local_id is not None or self.id is not None:
             struct['id'] = self._local_id or self.id
         return self.__class__.where(struct)
-
+    
     @classmethod
     def where(cls, struct):
         """ Search can be started via a dictionary containing a search
         construct.
-
+        
         Calling this method with a search struct will return a `FHIRSearch`
         object representing the search struct
-
+        
         :param dict struct: A search structure
         :returns: A FHIRSearch instance
         """

--- a/fhir-parser-resources/fhirabstractresource.py
+++ b/fhir-parser-resources/fhirabstractresource.py
@@ -111,8 +111,8 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         instance.origin_server = server
         return instance
 
-    def createUrl(self):
-        """ Get the URL on the server for creating the resource.
+    def createPath(self):
+        """ Get the endpoint on the server for creating the resource.
 
         :returns: The resource endpoint or None for the root endpoint
         """
@@ -136,7 +136,7 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if self.id:
             raise Exception("This resource already has an id, cannot create")
 
-        ret = srv.post_json(self.createUrl(), self.as_json())
+        ret = srv.post_json(self.createPath(), self.as_json())
         if len(ret.text) > 0:
             return ret.json()
         return None

--- a/fhir-parser-resources/fhirabstractresource.py
+++ b/fhir-parser-resources/fhirabstractresource.py
@@ -11,19 +11,19 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
     """ Extends the FHIRAbstractBase with server talking capabilities.
     """
     resource_type = 'FHIRAbstractResource'
-    
+
     def __init__(self, jsondict=None, strict=True):
         self._server = None
         """ The server the instance was read from. """
-        
+
         # raise if "resourceType" does not match
         if jsondict is not None and 'resourceType' in jsondict \
             and jsondict['resourceType'] != self.resource_type:
             raise Exception("Attempting to instantiate {} with resource data that defines a resourceType of \"{}\""
                 .format(self.__class__, jsondict['resourceType']))
-        
+
         super(FHIRAbstractResource, self).__init__(jsondict=jsondict, strict=strict)
-    
+
     @classmethod
     def _with_json_dict(cls, jsondict):
         """ Overridden to use a factory if called when "resourceType" is
@@ -32,31 +32,31 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if not isinstance(jsondict, dict):
             raise Exception("Cannot use this method with anything but a JSON dictionary, got {}"
                 .format(jsondict))
-        
+
         res_type = jsondict.get('resourceType')
         if res_type and res_type != cls.resource_type:
             return fhirelementfactory.FHIRElementFactory.instantiate(res_type, jsondict)
         return super(FHIRAbstractResource, cls)._with_json_dict(jsondict)
-    
+
     def as_json(self):
         js = super(FHIRAbstractResource, self).as_json()
         js['resourceType'] = self.resource_type
         return js
-    
-    
+
+
     # MARK: Handling Paths
-    
+
     def relativeBase(self):
         return self.__class__.resource_type
-    
+
     def relativePath(self):
         if self.id is None:
             return self.relativeBase()
         return "{}/{}".format(self.relativeBase(), self.id)
-    
-    
+
+
     # MARK: - Server Connection
-    
+
     @property
     def origin_server(self):
         """ Walks the owner hierarchy until it finds an owner with a server.
@@ -72,31 +72,31 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
     def origin_server(self, server):
         """ Sets the server on an element. """
         self._server = server
-    
+
     @classmethod
     def read(cls, rem_id, server):
         """ Read the resource with the given id from the given server. The
         passed-in server instance must support a `request_json()` method call,
         taking a relative path as first (and only mandatory) argument.
-        
+
         :param str rem_id: The id of the resource on the remote server
         :param FHIRServer server: An instance of a FHIR server or compatible class
         :returns: An instance of the receiving class
         """
         if not rem_id:
             raise Exception("Cannot read resource without remote id")
-        
+
         path = '{}/{}'.format(cls.resource_type, rem_id)
         instance = cls.read_from(path, server)
         instance._local_id = rem_id
-        
+
         return instance
-    
+
     @classmethod
     def read_from(cls, path, server):
         """ Requests data from the given REST path on the server and creates
         an instance of the receiving class.
-        
+
         :param str path: The REST path to read from
         :param FHIRServer server: An instance of a FHIR server or compatible class
         :returns: An instance of the receiving class
@@ -105,16 +105,28 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot read resource without REST path")
         if server is None:
             raise Exception("Cannot read resource without server instance")
-        
+
         ret = server.request_json(path)
         instance = cls(jsondict=ret)
         instance.origin_server = server
         return instance
-    
+
+    def createUrl(self):
+        """ Get the URL on the server for creating the resource.
+
+        :returns: The resource endpoint or None for the root endpoint
+        """
+        root_post_types = ("batch", "transaction")
+
+        if self.resource_type == "Bundle" and self.type in root_post_types:
+            return None
+
+        return self.relativeBase()
+
     def create(self, server):
         """ Attempt to create the receiver on the given server, using a POST
         command.
-        
+
         :param FHIRServer server: The server to create the receiver on
         :returns: None or the response JSON on success
         """
@@ -123,16 +135,16 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot create a resource without a server")
         if self.id:
             raise Exception("This resource already has an id, cannot create")
-        
-        ret = srv.post_json(self.relativeBase(), self.as_json())
+
+        ret = srv.post_json(self.createUrl(), self.as_json())
         if len(ret.text) > 0:
             return ret.json()
         return None
-    
+
     def update(self, server=None):
         """ Update the receiver's representation on the given server, issuing
         a PUT command.
-        
+
         :param FHIRServer server: The server to update the receiver on;
             optional, will use the instance's `server` if needed.
         :returns: None or the response JSON on success
@@ -142,15 +154,15 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot update a resource that does not have a server")
         if not self.id:
             raise Exception("Cannot update a resource that does not have an id")
-        
+
         ret = srv.put_json(self.relativePath(), self.as_json())
         if len(ret.text) > 0:
             return ret.json()
         return None
-    
+
     def delete(self, server=None):
         """ Delete the receiver from the given server with a DELETE command.
-        
+
         :param FHIRServer server: The server to update the receiver on;
             optional, will use the instance's `server` if needed.
         :returns: None or the response JSON on success
@@ -160,22 +172,22 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot delete a resource that does not have a server")
         if not self.id:
             raise Exception("Cannot delete a resource that does not have an id")
-        
+
         ret = srv.delete_json(self.relativePath())
         if len(ret.text) > 0:
             return ret.json()
         return None
-    
-    
+
+
     # MARK: - Search
-    
+
     def search(self, struct=None):
         """ Search can be started via a dictionary containing a search
         construct.
-        
+
         Calling this method with a search struct will return a `FHIRSearch`
         object representing the search struct, with "$type" and "id" added.
-        
+
         :param dict struct: An optional search structure
         :returns: A FHIRSearch instance
         """
@@ -184,15 +196,15 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if self._local_id is not None or self.id is not None:
             struct['id'] = self._local_id or self.id
         return self.__class__.where(struct)
-    
+
     @classmethod
     def where(cls, struct):
         """ Search can be started via a dictionary containing a search
         construct.
-        
+
         Calling this method with a search struct will return a `FHIRSearch`
         object representing the search struct
-        
+
         :param dict struct: A search structure
         :returns: A FHIRSearch instance
         """

--- a/fhirclient/models/fhirabstractresource.py
+++ b/fhirclient/models/fhirabstractresource.py
@@ -11,19 +11,19 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
     """ Extends the FHIRAbstractBase with server talking capabilities.
     """
     resource_type = 'FHIRAbstractResource'
-
+    
     def __init__(self, jsondict=None, strict=True):
         self._server = None
         """ The server the instance was read from. """
-
+        
         # raise if "resourceType" does not match
         if jsondict is not None and 'resourceType' in jsondict \
             and jsondict['resourceType'] != self.resource_type:
             raise Exception("Attempting to instantiate {} with resource data that defines a resourceType of \"{}\""
                 .format(self.__class__, jsondict['resourceType']))
-
+        
         super(FHIRAbstractResource, self).__init__(jsondict=jsondict, strict=strict)
-
+    
     @classmethod
     def _with_json_dict(cls, jsondict):
         """ Overridden to use a factory if called when "resourceType" is
@@ -32,31 +32,31 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if not isinstance(jsondict, dict):
             raise Exception("Cannot use this method with anything but a JSON dictionary, got {}"
                 .format(jsondict))
-
+        
         res_type = jsondict.get('resourceType')
         if res_type and res_type != cls.resource_type:
             return fhirelementfactory.FHIRElementFactory.instantiate(res_type, jsondict)
         return super(FHIRAbstractResource, cls)._with_json_dict(jsondict)
-
+    
     def as_json(self):
         js = super(FHIRAbstractResource, self).as_json()
         js['resourceType'] = self.resource_type
         return js
-
-
+    
+    
     # MARK: Handling Paths
-
+    
     def relativeBase(self):
         return self.__class__.resource_type
-
+    
     def relativePath(self):
         if self.id is None:
             return self.relativeBase()
         return "{}/{}".format(self.relativeBase(), self.id)
-
-
+    
+    
     # MARK: - Server Connection
-
+    
     @property
     def origin_server(self):
         """ Walks the owner hierarchy until it finds an owner with a server.
@@ -72,31 +72,31 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
     def origin_server(self, server):
         """ Sets the server on an element. """
         self._server = server
-
+    
     @classmethod
     def read(cls, rem_id, server):
         """ Read the resource with the given id from the given server. The
         passed-in server instance must support a `request_json()` method call,
         taking a relative path as first (and only mandatory) argument.
-
+        
         :param str rem_id: The id of the resource on the remote server
         :param FHIRServer server: An instance of a FHIR server or compatible class
         :returns: An instance of the receiving class
         """
         if not rem_id:
             raise Exception("Cannot read resource without remote id")
-
+        
         path = '{}/{}'.format(cls.resource_type, rem_id)
         instance = cls.read_from(path, server)
         instance._local_id = rem_id
-
+        
         return instance
-
+    
     @classmethod
     def read_from(cls, path, server):
         """ Requests data from the given REST path on the server and creates
         an instance of the receiving class.
-
+        
         :param str path: The REST path to read from
         :param FHIRServer server: An instance of a FHIR server or compatible class
         :returns: An instance of the receiving class
@@ -105,7 +105,7 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot read resource without REST path")
         if server is None:
             raise Exception("Cannot read resource without server instance")
-
+        
         ret = server.request_json(path)
         instance = cls(jsondict=ret)
         instance.origin_server = server
@@ -126,7 +126,7 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
     def create(self, server):
         """ Attempt to create the receiver on the given server, using a POST
         command.
-
+        
         :param FHIRServer server: The server to create the receiver on
         :returns: None or the response JSON on success
         """
@@ -140,11 +140,11 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if len(ret.text) > 0:
             return ret.json()
         return None
-
+    
     def update(self, server=None):
         """ Update the receiver's representation on the given server, issuing
         a PUT command.
-
+        
         :param FHIRServer server: The server to update the receiver on;
             optional, will use the instance's `server` if needed.
         :returns: None or the response JSON on success
@@ -154,15 +154,15 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot update a resource that does not have a server")
         if not self.id:
             raise Exception("Cannot update a resource that does not have an id")
-
+        
         ret = srv.put_json(self.relativePath(), self.as_json())
         if len(ret.text) > 0:
             return ret.json()
         return None
-
+    
     def delete(self, server=None):
         """ Delete the receiver from the given server with a DELETE command.
-
+        
         :param FHIRServer server: The server to update the receiver on;
             optional, will use the instance's `server` if needed.
         :returns: None or the response JSON on success
@@ -172,22 +172,22 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot delete a resource that does not have a server")
         if not self.id:
             raise Exception("Cannot delete a resource that does not have an id")
-
+        
         ret = srv.delete_json(self.relativePath())
         if len(ret.text) > 0:
             return ret.json()
         return None
-
-
+    
+    
     # MARK: - Search
-
+    
     def search(self, struct=None):
         """ Search can be started via a dictionary containing a search
         construct.
-
+        
         Calling this method with a search struct will return a `FHIRSearch`
         object representing the search struct, with "$type" and "id" added.
-
+        
         :param dict struct: An optional search structure
         :returns: A FHIRSearch instance
         """
@@ -196,15 +196,15 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if self._local_id is not None or self.id is not None:
             struct['id'] = self._local_id or self.id
         return self.__class__.where(struct)
-
+    
     @classmethod
     def where(cls, struct):
         """ Search can be started via a dictionary containing a search
         construct.
-
+        
         Calling this method with a search struct will return a `FHIRSearch`
         object representing the search struct
-
+        
         :param dict struct: A search structure
         :returns: A FHIRSearch instance
         """

--- a/fhirclient/models/fhirabstractresource.py
+++ b/fhirclient/models/fhirabstractresource.py
@@ -111,8 +111,8 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         instance.origin_server = server
         return instance
 
-    def createUrl(self):
-        """ Get the URL on the server for creating the resource.
+    def createPath(self):
+        """ Get the endpoint on the server for creating the resource.
 
         :returns: The resource endpoint or None for the root endpoint
         """
@@ -136,7 +136,7 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if self.id:
             raise Exception("This resource already has an id, cannot create")
 
-        ret = srv.post_json(self.createUrl(), self.as_json())
+        ret = srv.post_json(self.createPath(), self.as_json())
         if len(ret.text) > 0:
             return ret.json()
         return None

--- a/fhirclient/models/fhirabstractresource.py
+++ b/fhirclient/models/fhirabstractresource.py
@@ -11,19 +11,19 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
     """ Extends the FHIRAbstractBase with server talking capabilities.
     """
     resource_type = 'FHIRAbstractResource'
-    
+
     def __init__(self, jsondict=None, strict=True):
         self._server = None
         """ The server the instance was read from. """
-        
+
         # raise if "resourceType" does not match
         if jsondict is not None and 'resourceType' in jsondict \
             and jsondict['resourceType'] != self.resource_type:
             raise Exception("Attempting to instantiate {} with resource data that defines a resourceType of \"{}\""
                 .format(self.__class__, jsondict['resourceType']))
-        
+
         super(FHIRAbstractResource, self).__init__(jsondict=jsondict, strict=strict)
-    
+
     @classmethod
     def _with_json_dict(cls, jsondict):
         """ Overridden to use a factory if called when "resourceType" is
@@ -32,31 +32,31 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if not isinstance(jsondict, dict):
             raise Exception("Cannot use this method with anything but a JSON dictionary, got {}"
                 .format(jsondict))
-        
+
         res_type = jsondict.get('resourceType')
         if res_type and res_type != cls.resource_type:
             return fhirelementfactory.FHIRElementFactory.instantiate(res_type, jsondict)
         return super(FHIRAbstractResource, cls)._with_json_dict(jsondict)
-    
+
     def as_json(self):
         js = super(FHIRAbstractResource, self).as_json()
         js['resourceType'] = self.resource_type
         return js
-    
-    
+
+
     # MARK: Handling Paths
-    
+
     def relativeBase(self):
         return self.__class__.resource_type
-    
+
     def relativePath(self):
         if self.id is None:
             return self.relativeBase()
         return "{}/{}".format(self.relativeBase(), self.id)
-    
-    
+
+
     # MARK: - Server Connection
-    
+
     @property
     def origin_server(self):
         """ Walks the owner hierarchy until it finds an owner with a server.
@@ -72,31 +72,31 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
     def origin_server(self, server):
         """ Sets the server on an element. """
         self._server = server
-    
+
     @classmethod
     def read(cls, rem_id, server):
         """ Read the resource with the given id from the given server. The
         passed-in server instance must support a `request_json()` method call,
         taking a relative path as first (and only mandatory) argument.
-        
+
         :param str rem_id: The id of the resource on the remote server
         :param FHIRServer server: An instance of a FHIR server or compatible class
         :returns: An instance of the receiving class
         """
         if not rem_id:
             raise Exception("Cannot read resource without remote id")
-        
+
         path = '{}/{}'.format(cls.resource_type, rem_id)
         instance = cls.read_from(path, server)
         instance._local_id = rem_id
-        
+
         return instance
-    
+
     @classmethod
     def read_from(cls, path, server):
         """ Requests data from the given REST path on the server and creates
         an instance of the receiving class.
-        
+
         :param str path: The REST path to read from
         :param FHIRServer server: An instance of a FHIR server or compatible class
         :returns: An instance of the receiving class
@@ -105,16 +105,28 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot read resource without REST path")
         if server is None:
             raise Exception("Cannot read resource without server instance")
-        
+
         ret = server.request_json(path)
         instance = cls(jsondict=ret)
         instance.origin_server = server
         return instance
-    
+
+    def createUrl(self):
+        """ Get the URL on the server for creating the resource.
+
+        :returns: The resource endpoint or None for the root endpoint
+        """
+        root_post_types = ("batch", "transaction")
+
+        if self.resource_type == "Bundle" and self.type in root_post_types:
+            return None
+
+        return self.relativeBase()
+
     def create(self, server):
         """ Attempt to create the receiver on the given server, using a POST
         command.
-        
+
         :param FHIRServer server: The server to create the receiver on
         :returns: None or the response JSON on success
         """
@@ -123,16 +135,16 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot create a resource without a server")
         if self.id:
             raise Exception("This resource already has an id, cannot create")
-        
-        ret = srv.post_json(self.relativeBase(), self.as_json())
+
+        ret = srv.post_json(self.createUrl(), self.as_json())
         if len(ret.text) > 0:
             return ret.json()
         return None
-    
+
     def update(self, server=None):
         """ Update the receiver's representation on the given server, issuing
         a PUT command.
-        
+
         :param FHIRServer server: The server to update the receiver on;
             optional, will use the instance's `server` if needed.
         :returns: None or the response JSON on success
@@ -142,15 +154,15 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot update a resource that does not have a server")
         if not self.id:
             raise Exception("Cannot update a resource that does not have an id")
-        
+
         ret = srv.put_json(self.relativePath(), self.as_json())
         if len(ret.text) > 0:
             return ret.json()
         return None
-    
+
     def delete(self, server=None):
         """ Delete the receiver from the given server with a DELETE command.
-        
+
         :param FHIRServer server: The server to update the receiver on;
             optional, will use the instance's `server` if needed.
         :returns: None or the response JSON on success
@@ -160,22 +172,22 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
             raise Exception("Cannot delete a resource that does not have a server")
         if not self.id:
             raise Exception("Cannot delete a resource that does not have an id")
-        
+
         ret = srv.delete_json(self.relativePath())
         if len(ret.text) > 0:
             return ret.json()
         return None
-    
-    
+
+
     # MARK: - Search
-    
+
     def search(self, struct=None):
         """ Search can be started via a dictionary containing a search
         construct.
-        
+
         Calling this method with a search struct will return a `FHIRSearch`
         object representing the search struct, with "$type" and "id" added.
-        
+
         :param dict struct: An optional search structure
         :returns: A FHIRSearch instance
         """
@@ -184,15 +196,15 @@ class FHIRAbstractResource(fhirabstractbase.FHIRAbstractBase):
         if self._local_id is not None or self.id is not None:
             struct['id'] = self._local_id or self.id
         return self.__class__.where(struct)
-    
+
     @classmethod
     def where(cls, struct):
         """ Search can be started via a dictionary containing a search
         construct.
-        
+
         Calling this method with a search struct will return a `FHIRSearch`
         object representing the search struct
-        
+
         :param dict struct: A search structure
         :returns: A FHIRSearch instance
         """


### PR DESCRIPTION
Supersedes #54, fixes #102

I'm not sure this is much of an improvement on #54 . I've added a createUrl() method as @p2 suggested. This might not have been what was intended. To me it would make sense for createUrl() to return relativeBase() in fhirabstractresource.py and for the Bundle class to override this. To do that I'd need some help working that into the resource template / generate_models script.

I would also add some tests but I need some help working out how to run the tests.