### PR TITLE
Add authorize for system app

### DIFF
--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -283,6 +283,7 @@ class FHIROAuth2Auth(FHIRAuth):
         del ret_params['access_token']
         
         if 'expires_in' in ret_params:
+            # TODO: Handle access token expires_in
             del ret_params['expires_in']
         
         # The refresh token issued by the authorization server. If present, the
@@ -298,6 +299,29 @@ class FHIROAuth2Auth(FHIRAuth):
         return ret_params
     
     
+    # MARK: Authorization
+
+    def authorize(self, server):
+        """ Perform authorization on behalf of a system. 
+        
+        :param server: The Server instance to use
+        """
+        logger.debug("SMART AUTH: Get access token")
+        token_params = self._token_params(server)
+        return self._request_access_token(server, token_params)
+
+    def _token_params(self, server):
+        """ The URL parameters to use when requesting access token. """
+        if server is None:
+            raise Exception("Cannot get token params without server instance")
+        
+        params = {
+            'grant_type': 'client_credentials',
+            'scope': server.desired_scope,
+        }
+        return params
+
+
     # MARK: Reauthorization
     
     def reauthorize(self, server):

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -2,6 +2,7 @@
 
 import uuid
 import logging
+from datetime import datetime, timedelta
 try:                                # Python 2.x
     import urlparse
     from urllib import urlencode
@@ -143,11 +144,14 @@ class FHIROAuth2Auth(FHIRAuth):
         self.app_secret = None
         self.access_token = None
         self.refresh_token = None
+        self.expires_at = None
         
         super(FHIROAuth2Auth, self).__init__(state=state)
     
     @property
     def ready(self):
+        if self.expires_at and self.expires_at < datetime.now():
+            self.reset()
         return True if self.access_token else False
     
     def reset(self):
@@ -283,7 +287,8 @@ class FHIROAuth2Auth(FHIRAuth):
         del ret_params['access_token']
         
         if 'expires_in' in ret_params:
-            # TODO: Handle access token expires_in
+            expires_in = ret_params.get('expires_in')
+            self.expires_at = datetime.now() + timedelta(seconds=expires_in)
             del ret_params['expires_in']
         
         # The refresh token issued by the authorization server. If present, the

--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -132,6 +132,11 @@ class FHIRClient(object):
         ctx = self.server.handle_callback(url) if self.server is not None else None
         self._handle_launch_context(ctx)
     
+    def authorize(self):
+        """ Try to authorize with the server. """
+        ctx = self.server.authorize() if self.server is not None else None
+        self._handle_launch_context(ctx)
+
     def reauthorize(self):
         """ Try to reauthorize with the server.
         

--- a/fhirclient/server.py
+++ b/fhirclient/server.py
@@ -120,7 +120,12 @@ class FHIRServer(object):
         if self.auth is None:
             raise Exception("Not ready to handle callback, I do not have an auth instance")
         return self.auth.handle_callback(url, self)
-    
+
+    def authorize(self):
+        if self.auth is None:
+            raise Exception("Not ready to authorize, I do not have an auth instance")
+        return self.auth.authorize(self) if self.auth is not None else None
+
     def reauthorize(self):
         if self.auth is None:
             raise Exception("Not ready to reauthorize, I do not have an auth instance")


### PR DESCRIPTION
According to http://fhir.cerner.com/authorization/#requesting-authorization-on-behalf-of-a-system

In order to refresh `access_token` after `expires_in` runs out, you can follow this pattern together with this PR:

```
from fhirclient.client import FHIRClient

class FHIRService:

    def __init__(self, settings=settings):
        assert len(settings), 'Missing `fhir` settings'
        self.client = FHIRClient(settings=settings)

    @property
    def server(self):
        if not self.client.ready:
            self.client.prepare()
            self.client.authorize()
        return self.client.server
```

And use this `FHIRService.server` property to perform FHIR requests.
