### PR TITLE
Fix reauthorization to work beyond the first time called

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,7 +15,8 @@ The following wonderful people contributed directly or indirectly to this projec
 - Josh Mandel <https://github.com/jmandel>
 - Nikolai Schwertner <https://github.com/nschwertner>
 - Pascal Pfiffner <https://github.com/p2>
-- Raheel Sayeed <https://github.com/raheelsayeed> 
+- Raheel Sayeed <https://github.com/raheelsayeed>
+- Tim Harsch <https://github.com/timharsch>
 - Trinadh Baranika <https://github.com/bktrinadh>
 
 Please add yourself here alphabetically when you submit your first pull request.

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -294,9 +294,8 @@ class FHIROAuth2Auth(FHIRAuth):
         # The refresh token issued by the authorization server. If present, the
         # app should discard any previous refresh_token associated with this
         # launch, replacing it with this new value.
-        refresh_token = ret_params.get('refresh_token')
-        if refresh_token is not None:
-            self.refresh_token = refresh_token
+        self.refresh_token = ret_params.get('refresh_token') or params.get('refresh_token')
+        if self.refresh_token is not None and 'refresh_token' in ret_params:
             del ret_params['refresh_token']
         
         logger.debug("SMART AUTH: Received access token: {0}, refresh token: {1}"

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -294,10 +294,11 @@ class FHIROAuth2Auth(FHIRAuth):
         # The refresh token issued by the authorization server. If present, the
         # app should discard any previous refresh_token associated with this
         # launch, replacing it with this new value.
-        self.refresh_token = ret_params.get('refresh_token') or params.get('refresh_token')
-        if self.refresh_token is not None and 'refresh_token' in ret_params:
-            del ret_params['refresh_token']
-        
+        refresh_token = ret_params.get('refresh_token') or params.get('refresh_token')
+        if refresh_token is not None:
+            self.refresh_token = refresh_token
+            if 'refresh_token' in ret_params:
+                del ret_params['refresh_token']
         logger.debug("SMART AUTH: Received access token: {0}, refresh token: {1}"
             .format(self.access_token is not None, self.refresh_token is not None))
         return ret_params


### PR DESCRIPTION
See also PR #127 and issue #112

This PR fixes a situation where the refresh_token is not properly address on calls beyond the first.