### PR TITLE
Add ability to use JWT tokens for auth

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,6 +11,7 @@ The following wonderful people contributed directly or indirectly to this projec
 
 - Alexandru Stanciu <https://github.com/ducu>
 - Andrew Bjonnes <https://github.com/abjonnes>
+- Armaghan Behlum <https://github.com/armaghan-behlum>
 - Erik Wiffin <https://github.com/erikwiffin>
 - Josh Mandel <https://github.com/jmandel>
 - Nikolai Schwertner <https://github.com/nschwertner>

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -145,6 +145,7 @@ class FHIROAuth2Auth(FHIRAuth):
         self.access_token = None
         self.refresh_token = None
         self.expires_at = None
+        self.jwt_token = None
         
         super(FHIROAuth2Auth, self).__init__(state=state)
     
@@ -324,6 +325,10 @@ class FHIROAuth2Auth(FHIRAuth):
             'grant_type': 'client_credentials',
             'scope': server.desired_scope,
         }
+
+        if self.jwt_token:
+            params['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+            params['client_assertion'] = self.jwt_token
         return params
 
 
@@ -391,7 +396,7 @@ class FHIROAuth2Auth(FHIRAuth):
         
         self.access_token = state.get('access_token') or self.access_token
         self.refresh_token = state.get('refresh_token') or self.refresh_token
-    
+        self.jwt_token = state.get('jwt_token') or self.jwt_token
 
     # MARK: Utilities    
     

--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -53,6 +53,11 @@ class FHIRClient(object):
         
         self.patient_id = None
         self._patient = None
+
+        self.jwt_token = None
+        """ If present, is included as part of the request to authenticate
+        with a backend system through a client_assertion parameter
+        """
         
         if save_func is None:
             raise Exception("Must supply a save_func when initializing the SMART client")
@@ -75,6 +80,7 @@ class FHIRClient(object):
             self.patient_id = settings.get('patient_id')
             self.scope = settings.get('scope', self.scope)
             self.launch_token = settings.get('launch_token')
+            self.jwt_token = settings.get('jwt_token', None)
             self.server = FHIRServer(self, base_uri=settings['api_base'])
         else:
             raise Exception("Must either supply settings or a state upon client initialization")
@@ -218,6 +224,7 @@ class FHIRClient(object):
             'server': self.server.state,
             'launch_token': self.launch_token,
             'launch_context': self.launch_context,
+            'jwt_token': self.jwt_token,
         }
     
     def from_state(self, state):
@@ -230,6 +237,7 @@ class FHIRClient(object):
         self.launch_token = state.get('launch_token') or self.launch_token
         self.launch_context = state.get('launch_context') or self.launch_context
         self.server = FHIRServer(self, state=state.get('server'))
+        self.jwt_token = state.get('jwt_token') or self.jwt_token
     
     def save_state (self):
         self._save_func(self.state)

--- a/fhirclient/server.py
+++ b/fhirclient/server.py
@@ -95,6 +95,7 @@ class FHIRServer(object):
                 'app_id': self.client.app_id if self.client is not None else None,
                 'app_secret': self.client.app_secret if self.client is not None else None,
                 'redirect_uri': self.client.redirect if self.client is not None else None,
+                'jwt_token': self.client.jwt_token if self.client is not None else None,
             }
             self.auth = FHIRAuth.from_capability_security(security, settings)
             self.should_save_state()


### PR DESCRIPTION
Used to obtain an access token for a backend service accessing an Epic endpoint: 
https://fhir.epic.com/Documentation?docId=oauth2&section=BackendOAuth2Guide

Tested locally by authorizing against Epic's Sandbox to fetch data: 
```
settings = {
    'app_id': APP_ID,
    'api_base': 'https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/',
    'scope': 'system/Observation.read system/Patient.read',
    'jwt_token': jwt_token
}

smart = client.FHIRClient(settings=settings)
```