### PR TITLE
Use relative paths for access to modules (avoid sys.path fiddling)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ session_data
 *.sublime-*
 
 .DS_Store
+.idea

--- a/fhirclient/__init__.py
+++ b/fhirclient/__init__.py
@@ -1,5 +1,0 @@
-import sys
-import os.path
-abspath = os.path.abspath(os.path.dirname(__file__))
-if abspath not in sys.path:
-    sys.path.insert(0, abspath)

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -328,7 +328,10 @@ class FHIROAuth2Auth(FHIRAuth):
 
         if self.jwt_token:
             params['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
-            params['client_assertion'] = self.jwt_token
+            if isinstance(self.jwt_token, str):
+                params['client_assertion'] = self.jwt_token
+            else:
+                params['client_assertion'] = self.jwt_token(self._token_uri)
         return params
 
 

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -288,7 +288,8 @@ class FHIROAuth2Auth(FHIRAuth):
         del ret_params['access_token']
         
         if 'expires_in' in ret_params:
-            expires_in = ret_params.get('expires_in')
+            # Value may be returned as int or string
+            expires_in = int(ret_params.get('expires_in'))
             self.expires_at = datetime.now() + timedelta(seconds=expires_in)
             del ret_params['expires_in']
         

--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from server import FHIRServer, FHIRUnauthorizedException, FHIRNotFoundException
+from .server import FHIRServer, FHIRUnauthorizedException, FHIRNotFoundException
 
 __version__ = '4.1.0'
 __author__ = 'SMART Platforms Team'

--- a/fhirclient/models/fhirabstractbase.py
+++ b/fhirclient/models/fhirabstractbase.py
@@ -8,6 +8,14 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+raise_on_schema_error = True
+
+def set_raise_on_schema_error(val):
+    global raise_on_schema_error
+    old = raise_on_schema_error
+    raise_on_schema_error = val
+    return old
+
 
 class FHIRValidationError(Exception):
     """ Exception raised when one or more errors occurred during model
@@ -227,7 +235,7 @@ class FHIRAbstractBase(object):
                 errs.append(AttributeError("Superfluous entry \"{}\" in data for {}"
                     .format(supflu, self)))
         
-        if len(errs) > 0:
+        if len(errs) > 0 and raise_on_schema_error:
             raise FHIRValidationError(errs)
     
     def as_json(self):
@@ -293,7 +301,7 @@ class FHIRAbstractBase(object):
                 errs.append(KeyError("Property \"{}\" on {} is not optional, you must provide a value for it"
                     .format(nonop, self)))
         
-        if len(errs) > 0:
+        if len(errs) > 0 and raise_on_schema_error:
             raise FHIRValidationError(errs)
         return js
     

--- a/fhirclient/server.py
+++ b/fhirclient/server.py
@@ -155,21 +155,25 @@ class FHIRServer(object):
         if self.auth is None:
             self.get_capability()
         return self.auth.ready if self.auth is not None else False
-    
-    def request_json(self, path, nosign=False):
+
+    def request_json(self, path, headers={}, nosign=False):
         """ Perform a request for JSON data against the server's base with the
         given relative path.
-        
+
         :param str path: The path to append to `base_uri`
         :param bool nosign: If set to True, the request will not be signed
         :throws: Exception on HTTP status >= 400
         :returns: Decoded JSON response
         """
-        headers = {'Accept': 'application/json'}
+
+        header_defaults = {'Accept': 'application/json'}
+        header_defaults.update(headers)
+        headers = header_defaults
+
         res = self._get(path, headers, nosign)
-        
+
         return res.json()
-    
+
     def request_data(self, path, headers={}, nosign=False):
         """ Perform a data request data against the server's base with the
         given relative path.

--- a/fhirclient/server.py
+++ b/fhirclient/server.py
@@ -9,7 +9,7 @@ try:                                # Python 2.x
 except ImportError as e:            # Python 3
     import urllib.parse as urlparse
 
-from auth import FHIRAuth
+from .auth import FHIRAuth
 
 FHIRJSONMimeType = 'application/fhir+json'
 
@@ -80,7 +80,7 @@ class FHIRServer(object):
         """
         if self._capability is None or force:
             logger.info('Fetching CapabilityStatement from {0}'.format(self.base_uri))
-            from models import capabilitystatement
+            from .models import capabilitystatement
             conf = capabilitystatement.CapabilityStatement.read_from('metadata', self)
             self._capability = conf
             


### PR DESCRIPTION
Removes code that fiddles with sys.path. This has resulted in multiple loads of the same module.

This is a minimal change; I did not get rid of all the other tests for python 2.

Tested with python 3.10. Rumor has it it will break on python 2, but do we care?

@ducu review?