### PR TITLE
Detect oauth2 even if there's no authorize_uri

### DIFF
--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -44,7 +44,6 @@ class FHIRAuth(object):
                                 state['token_uri'] = ee.valueUri
                             elif 'authorize' == ee.url:
                                 state['authorize_uri'] = ee.valueUri
-                                auth_type = 'oauth2'
                             elif 'register' == ee.url:
                                 state['registration_uri'] = ee.valueUri
                         break
@@ -56,9 +55,11 @@ class FHIRAuth(object):
                     state['registration_uri'] = e.valueUri
                 elif "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris#authorize" == e.url:
                     state['authorize_uri'] = e.valueUri
-                    auth_type = 'oauth2'
                 elif "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris#token" == e.url:
                     state['token_uri'] = e.valueUri
+
+            if 'authorize_uri' in state or ('token_uri' in state and 'jwt_token' in state):
+                auth_type = 'oauth2'
         
         return cls.create(auth_type, state=state)
     


### PR DESCRIPTION
As long as we have a JWT and there's a token_uri, we can talk oauth2.

I ran into this while testing the bulk export flow against `https://bulk-data.smarthealthit.org` which does not expose an `authorize_uri`, but does expose `token_uri` and can talk oauth2 with JWTs just fine.

I am not confident that this is the _best_ solution, but it is _a_ solution. Should the code be even dumber and just use oauth2 if the `http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris` security extension is present at all? Given that there is no other auth system to fall back to, it seems reasonable to err on the side of oauth2. Happy to tweak this as folks like, or leave it as is.