### PR TITLE
ci: disable coverage checking action for now

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,14 +41,14 @@ jobs:
         run: |
           coverage report -m --skip-covered
 
-      - name: Check coverage report
-        # Disable coverage checking from forks until there is a secure fix for:
-        # https://github.com/orgoro/coverage/issues/259
-        if: github.ref != 'refs/heads/main' && ${{ ! github.event.pull_request.head.repo.fork }}
-        uses: orgoro/coverage@v3.2
-        with:
-          coverageFile: coverage.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          thresholdAll: .45
-          thresholdNew: 1
-          thresholdModified: .40
+# Disable coverage checking until there is a secure fix for:
+# https://github.com/orgoro/coverage/issues/259
+#      - name: Check coverage report
+#        if: github.ref != 'refs/heads/main'
+#        uses: orgoro/coverage@v3.2
+#        with:
+#          coverageFile: coverage.xml
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          thresholdAll: .45
+#          thresholdNew: 1
+#          thresholdModified: .40


### PR DESCRIPTION
It has a permission issue with PRs from forks, and until we figure out how to fix that securely, let's just disable the check.