### PR TITLE
flask demo: don't provide a meaningless default server

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,13 @@ print(patient.name[0].given)
 Take a look at
 [flask_app.py](https://github.com/smart-on-fhir/client-py/blob/main/demos/flask/flask_app.py)
 to see how you can use the client in a simple (Flask) app.
-This app starts a web server,
-listening on [_localhost:8000_](http://localhost:8000),
-and prompts you to log in to our sandbox server and select a patient.
+
+This demo requires a server that is capable of SMART OAuth logins for patients,
+so make sure you have such a server ready first.
+
+This app will start a web server,
+listen on [_localhost:8000_](http://localhost:8000),
+and prompt you to log in to our sandbox server and select a patient.
 It then retrieves the selected patient's demographics and med prescriptions
 and lists them on a simple HTML page.
 
@@ -192,6 +196,7 @@ and install the needed packages as shown:
     python3 -m venv env
     . env/bin/activate
     pip install -r requirements.txt
+    # Edit flask_app.py and put your own server's URL as api_base.
     ./flask_app.py
 
 


### PR DESCRIPTION
Instead, ask the user to provide the test server. Which is annoying, but...

The flask demo needs an OAuth-capable server, and we are currently using a no-auth server, so the user just sees a message "nothing to demo here".

This is because:
- The old (oauth) server that presumably worked was taken down.
- We put in the new (non-oauth) R4 modern test server.
- The modern server has a temporary bug where its metadata doesn't validate
- So we didn't notice that the flask server wouldn't work even if validation passed.

All of the [public test servers](https://confluence.hl7.org/display/FHIR/Public+Test+Servers) I know about require you to email someone to set up a user. So it's not obvious what a good replacement would be.

Honestly, we should probably just add a new default demo that supports no-auth servers and still shows something interesting.

But for now, this gets the flask demo to a more honest place and asks the user to provide their own server. :shrug:

Fixes #162 
Fixes #86