### PR TITLE
oauth: handle a string expires_in value gracefully

### DIFF
--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -283,7 +283,7 @@ class FHIROAuth2Auth(FHIRAuth):
         del ret_params['access_token']
         
         if 'expires_in' in ret_params:
-            expires_in = ret_params.get('expires_in')
+            expires_in = int(ret_params['expires_in'])
             self.expires_at = datetime.now() + timedelta(seconds=expires_in)
             del ret_params['expires_in']
         


### PR DESCRIPTION
If an OAuth token's expires_in field is a string instead of an int, simply try to convert it to an int first.

Fixes https://github.com/smart-on-fhir/client-py/issues/179