### PR TITLE
fix: avoid iterating over a None entry result for an empty search

### DIFF
--- a/fhirclient/_utils.py
+++ b/fhirclient/_utils.py
@@ -1,9 +1,7 @@
 import urllib
 from typing import Optional
 
-import requests
-
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterator
 
 if TYPE_CHECKING:
     from fhirclient.server import FHIRServer
@@ -92,7 +90,7 @@ def _execute_pagination_request(sanitized_url: str, server: 'FHIRServer') -> 'Bu
     return Bundle.read_from(sanitized_url, server)
 
 
-def iter_pages(first_bundle: 'Bundle', server: 'FHIRServer') -> Iterable['Bundle']:
+def iter_pages(first_bundle: 'Bundle', server: 'FHIRServer') -> Iterator['Bundle']:
     """
     Iterator that yields each page of results as a FHIR Bundle.
 

--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -1,7 +1,7 @@
 import logging
 from .server import FHIRServer, FHIRUnauthorizedException, FHIRNotFoundException
 
-__version__ = '4.3.0'
+__version__ = '4.3.1'
 __author__ = 'SMART Platforms Team'
 __license__ = 'APACHE2'
 __copyright__ = "Copyright 2017 Boston Children's Hospital"

--- a/tests/models/fhirsearch_perform_iter_test.py
+++ b/tests/models/fhirsearch_perform_iter_test.py
@@ -240,6 +240,40 @@ class TestFHIRSearchIter(unittest.TestCase):
         self.assertEqual(result[1].id, "3124")
         self.assertEqual(result[2].id, "3125")
 
+    @responses.activate
+    def test_perform_resources_iter_null_bundle(self):
+        """This happens when no results are found for a search."""
+        # Mock the network response for the initial search request
+        bundle_content = {
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "entry": None,
+        }
+
+        # Mock the single page response
+        self.add_mock_response("https://example.com/Bundle?patient=347&_count=1", bundle_content)
+
+        # Call perform_resources_iter with the server URL
+        result = list(self.search.perform_resources_iter(self.mock_server))
+        self.assertEqual(result, [])
+
+    @responses.activate
+    def test_perform_resources_iter_null_resource(self):
+        """This shouldn't happen for search results, but the spec allows .resource to be empty"""
+        # Mock the network response for the initial search request
+        bundle_content = {
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "entry": [{}],
+        }
+
+        # Mock the single page response
+        self.add_mock_response("https://example.com/Bundle?patient=347&_count=1", bundle_content)
+
+        # Call perform_resources_iter with the server URL
+        result = list(self.search.perform_resources_iter(self.mock_server))
+        self.assertEqual(result, [])
+
 
 # Network-level Mocking
 class MockServer(server.FHIRServer):


### PR DESCRIPTION
Also, avoid a deprecation warning for perform_iter()

Fixes https://github.com/smart-on-fhir/client-py/issues/185