### PR TITLE
server: send correct Accept=application/fhir+json HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ patient = Patient.read('2cda5aad-e409-4070-9a15-e1c35c46ed5a', smart.server)
 print(patient.birthDate.isostring)
 # '1992-07-03'
 print(smart.human_name(patient.name[0]))
-# 'Mr. Geoffrey Abbott'
+# 'Mr. steve Smith'
 ```
 If this is a protected server, you will first have to send your user to the authorization endpoint to log in.
 Just call `smart.authorize_url` to obtain the correct URL.
@@ -90,7 +90,7 @@ from fhirclient.models.patient import Patient
 smart = server.FHIRServer(None, 'https://r4.smarthealthit.org')
 patient = Patient.read('2cda5aad-e409-4070-9a15-e1c35c46ed5a', smart)
 print(patient.name[0].given)
-# ['Geoffrey']
+# ['steve']
 ```
 
 ##### Search Records on Server

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "SMART on FHIR Python Client"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 4.3.1
+PROJECT_NUMBER         = 4.3.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -1,7 +1,7 @@
 import logging
 from .server import FHIRServer, FHIRUnauthorizedException, FHIRNotFoundException
 
-__version__ = '4.3.1'
+__version__ = '4.3.2'  # Update docs/Doxyfile too when you bump this
 __author__ = 'SMART Platforms Team'
 __license__ = 'APACHE2'
 __copyright__ = "Copyright 2017 Boston Children's Hospital"

--- a/fhirclient/server.py
+++ b/fhirclient/server.py
@@ -159,19 +159,18 @@ class FHIRServer(object):
         :throws: Exception on HTTP status >= 400
         :returns: Decoded JSON response
         """
-        headers = {'Accept': 'application/json'}
-        res = self._get(path, headers, nosign)
+        res = self._get(path, nosign=nosign)
         
         return res.json()
     
-    def request_data(self, path, headers={}, nosign=False):
+    def request_data(self, path, headers=None, nosign=False):
         """ Perform a data request data against the server's base with the
         given relative path.
         """
-        res = self._get(path, headers, nosign)
+        res = self._get(path, headers=headers, nosign=nosign)
         return res.content
     
-    def _get(self, path, headers={}, nosign=False):
+    def _get(self, path, headers=None, nosign=False):
         """ Issues a GET request.
         
         :returns: The response object
@@ -184,7 +183,8 @@ class FHIRServer(object):
             'Accept-Charset': 'UTF-8',
         }
         # merge in user headers with defaults
-        header_defaults.update(headers)
+        if headers:
+            header_defaults.update(headers)
         # use the merged headers in the request
         headers = header_defaults
         if not nosign and self.auth is not None and self.auth.can_sign_headers():
@@ -251,10 +251,6 @@ class FHIRServer(object):
         :throws: Exception on HTTP status >= 400
         :returns: The response object
         """
-        headers = {
-            'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
-            'Accept': 'application/json',
-        }
         res = self.session.post(url, data=formdata, auth=auth)
         self.raise_for_status(res)
         return res
@@ -276,7 +272,7 @@ class FHIRServer(object):
             headers = self.auth.signed_headers(headers)
         
         # perform the request but intercept 401 responses, raising our own Exception
-        res = self.session.delete(url)
+        res = self.session.delete(url, headers=headers)
         self.raise_for_status(res)
         return res
     


### PR DESCRIPTION
First and foremost, stop requesting application/json for FHIR objects. The correct type is application/fhir+json. The [spec](https://www.hl7.org/fhir/R4/http.html) says:

"The correct mime type SHALL be used by clients and servers: JSON: application/fhir+json"
and
"If a client provides a generic mime type in the Accept header (application/xml, text/json, or application/json), the server SHOULD respond with the requested mime type, using the XML or JSON formats described in this specification as the best representation for the named mime type (except for binary - see the note on the Binary resource)."

So this was only ever working by accident, and wasn't correct for Binary resources, which when provided a non-fhir+json Accept header are supposed to return their binary content, not the FHIR object.

So now we send the right header.

Also for DELETE requests, send signed headers if possible.

Fixes https://github.com/smart-on-fhir/client-py/issues/191