### PR TITLE
Add PKCE parameters to authorization code exchange

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,6 +18,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - Martin Burchell <https://github.com/martinburchell>
 - Matt Garber <https://github.com/dogversioning>
 - Michael Terry <https://github.com/mikix>
+- Min Ragan-Kelley <https://github.com/minrk>
 - Nikolai Schwertner <https://github.com/nschwertner>
 - Pascal Pfiffner <https://github.com/p2>
 - Raheel Sayeed <https://github.com/raheelsayeed>

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -1,5 +1,8 @@
+import base64
+import hashlib
 import uuid
 import logging
+import secrets
 from datetime import datetime, timedelta
 import urllib.parse as urlparse
 from urllib.parse import urlencode
@@ -141,7 +144,8 @@ class FHIROAuth2Auth(FHIRAuth):
         self.refresh_token = None
         self.expires_at = None
         self.jwt_token = None
-        
+        self.code_verifier = None
+
         super(FHIROAuth2Auth, self).__init__(state=state)
     
     @property
@@ -154,8 +158,8 @@ class FHIROAuth2Auth(FHIRAuth):
         super(FHIROAuth2Auth, self).reset()
         self.access_token = None
         self.auth_state = None
-    
-    
+        self.code_verifier = None
+
     # MARK: Signing/Authorizing Request Headers
     
     def can_sign_headers(self):
@@ -214,6 +218,18 @@ class FHIROAuth2Auth(FHIRAuth):
         }
         if server.launch_token is not None:
             params['launch'] = server.launch_token
+        # PKCE parameters
+        # server is free to ignore PKCE,
+        # so it should never be wrong to include it
+        if self.code_verifier is None:
+            self.code_verifier = secrets.token_urlsafe(64)
+            server.should_save_state()
+        verifier_hash = hashlib.sha256(self.code_verifier.encode()).digest()
+        params["code_challenge"] = (
+            base64.urlsafe_b64encode(verifier_hash).decode().rstrip("=")
+        )
+        params["code_challenge_method"] = "S256"
+
         return params
     
     def handle_callback(self, url, server):
@@ -259,6 +275,7 @@ class FHIROAuth2Auth(FHIRAuth):
             'grant_type': 'authorization_code',
             'redirect_uri': self._redirect_uri,
             'state': self.auth_state,
+            'code_verifier': self.code_verifier,
         }
     
     def _request_access_token(self, server, params):
@@ -374,7 +391,9 @@ class FHIROAuth2Auth(FHIRAuth):
             s['access_token'] = self.access_token
         if self.refresh_token is not None:
             s['refresh_token'] = self.refresh_token
-        
+        if self.code_verifier is not None:
+            s['code_verifier'] = self.code_verifier
+
         return s
     
     def from_state(self, state):
@@ -392,6 +411,7 @@ class FHIROAuth2Auth(FHIRAuth):
         self.access_token = state.get('access_token') or self.access_token
         self.refresh_token = state.get('refresh_token') or self.refresh_token
         self.jwt_token = state.get('jwt_token') or self.jwt_token
+        self.code_verifier = state.get("code_verifier") or self.code_verifier
 
     # MARK: Utilities    
     

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -1,9 +1,12 @@
+import base64
+import hashlib
 import io
 import json
 import os
 import shutil
 import tempfile
 import unittest
+from urllib.parse import urlparse, parse_qs, urlencode
 
 import requests
 import responses
@@ -122,6 +125,46 @@ class TestServer(unittest.TestCase):
         self.assertNotIn("Authorization", mock.calls[1].request.headers)
 
         self.assertEqual(mock.call_count, 2)
+
+    @responses.activate
+    def test_pkce(self):
+        fhir = self.create_server()
+        state = fhir.state
+        assert state["auth"].get("code_verifier") is None
+        assert fhir.auth.code_verifier is None
+        uri = fhir.authorize_uri
+        assert fhir.auth.code_verifier is not None
+        state = fhir.state
+        assert state["auth"]["code_verifier"] == fhir.auth.code_verifier
+
+        authorize_args = parse_qs(urlparse(uri).query)
+        assert "code_challenge_method" in authorize_args
+        assert authorize_args["code_challenge_method"][0] == "S256"
+        assert "code_challenge" in authorize_args
+
+        # check hash
+        verifier_hash = hashlib.sha256(fhir.auth.code_verifier.encode()).digest()
+        b64_hash = base64.urlsafe_b64encode(verifier_hash).decode().rstrip("=")
+        assert authorize_args["code_challenge"][0] == b64_hash
+
+        # check oauth callback
+        mock = responses.add(
+            "POST",
+            fhir.auth._token_uri,
+            json={
+                "access_token": "xyz",
+            },
+        )
+
+        callback_url = f"https://example.org/callback?" + urlencode(
+            dict(code="abc123", state=fhir.auth.auth_state)
+        )
+        fhir.handle_callback(callback_url)
+        assert mock.call_count == 1
+        token_call = mock.calls[0]
+        params = parse_qs(token_call.request.body)
+        assert params["code"][0] == "abc123"
+        assert params["code_verifier"][0] == fhir.auth.code_verifier
 
 
 class MockServer(server.FHIRServer):


### PR DESCRIPTION
I've added a test, but it doesn't really verify that the challenge is computed properly, since it's the same code in both the test and the code. I have tested this with my medplum testing environment, and verified that injecting a typo in the verifier does result in rejected authorization, as it should.

Should be fully backward compatible even with servers that don't support PKCE, because authorization servers [are required to ignore unsupported parameters](https://datatracker.ietf.org/doc/html/rfc6749#:~:text=The%20authorization%20server%20MUST%20ignore).