### PR TITLE
Remove asserts from client library code

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,6 +10,7 @@ Contributors
 The following wonderful people contributed directly or indirectly to this project:
 
 - Alexandru Stanciu <https://github.com/ducu>
+- Alexander Gorokhov <https://github.com/sashgorokhov>
 - Andrew Bjonnes <https://github.com/abjonnes>
 - Armaghan Behlum <https://github.com/armaghan-behlum>
 - Erik Wiffin <https://github.com/erikwiffin>

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -138,7 +138,9 @@ class FHIRAuth:
 
     def from_state(self, state):
         """Update ivars from given state information."""
-        assert state
+        if not state:
+            raise ValueError(f"Parameter `state` must not be None or empty, got: {state}")
+
         self.app_id = state.get("app_id") or self.app_id
 
 

--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -226,7 +226,9 @@ class FHIRClient:
         }
 
     def from_state(self, state):
-        assert state
+        if not state:
+            raise ValueError(f"Parameter `state` must not be None or empty, got: {state}")
+
         self.app_id = state.get("app_id") or self.app_id
         self.app_secret = state.get("app_secret") or self.app_secret
         self.scope = state.get("scope") or self.scope
@@ -234,7 +236,12 @@ class FHIRClient:
         self.patient_id = state.get("patient_id") or self.patient_id
         self.launch_token = state.get("launch_token") or self.launch_token
         self.launch_context = state.get("launch_context") or self.launch_context
-        self.server = FHIRServer(self, state=state.get("server"))
+        base_uri = self.server.base_uri if self.server is not None else None
+        self.server = FHIRServer(
+            client=self,
+            base_uri=state.get('server', {}).get('base_uri') or base_uri,
+            state=state.get("server")
+        )
         self.jwt_token = state.get("jwt_token") or self.jwt_token
 
     def save_state(self):

--- a/fhirclient/server.py
+++ b/fhirclient/server.py
@@ -180,9 +180,12 @@ class FHIRServer:
     def _get(self, path, headers=None, nosign=False):
         """Issues a GET request.
 
+        :raises ValueError: if `path` is empty or None
         :returns: The response object
         """
-        assert self.base_uri and path
+        if not path:
+            raise ValueError(f"Parameter `path` must not be None or empty, got: {path}")
+
         url = urlparse.urljoin(self.base_uri, path)
 
         header_defaults = {
@@ -309,6 +312,7 @@ class FHIRServer:
 
     def from_state(self, state):
         """Update ivars from given state information."""
-        assert state
+        if not state:
+            raise ValueError(f"Parameter `state` must not be None or empty, got: {state}")
         self.base_uri = state.get("base_uri") or self.base_uri
         self.auth = FHIRAuth.create(state.get("auth_type"), state=state.get("auth"))


### PR DESCRIPTION
Using asserts in production code can be dangerous in cases where python interpreter is running with [-O optimization option](https://docs.python.org/3/using/cmdline.html#cmdoption-O), which will remove all [assertion statements](https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement) completely from bytecode.

There multiple ways how to address this, one simplest would be is to replace assert statement with if condition that would raise an exception, making check logically equivalent.

Originally I wanted to refactor logic to make these checks unnecessary at all, but that resulted in lots of changes that snowballed out of control. I've found couple of logical loopholes that allow creating instances with broken state. Being first time contributor in this project I decided to start small first.

Speaking of loopholes, there are several:
- FHIRServer modifies and checks base_uri only during `__init__`, and does not check what is provided into `.from_state`
- FHIRClient does not check that app_id and api_base (or base_uri) are provided via state
- It is possible to instantiate FHIRClient with its server being in unusable state

To address all these, I would honestly start with adding typing into the whole library, and then start adjusting any logic responsible for instance initialization and correct-state-insurance into from_state method. "state" and "from_state" can operate on TypedDict instances (ok to use since this library is python >=3.10), and through them, library can communicate which attributes are required or not.

What do you guys think? I'd be excited to help y'all with these improvements.