### PR TITLE
Fix: Handle incorrectly labeled 'subtype' field in Contract resource

### DIFF
--- a/fhirclient/models/fhirabstractbase.py
+++ b/fhirclient/models/fhirabstractbase.py
@@ -159,6 +159,17 @@ class FHIRAbstractBase(object):
             raise FHIRValidationError("Non-dict type {} fed to `update_with_json` on {}"
                 .format(type(jsondict), type(self)))
         
+        # Fix incorrect field names and structure (ONLY for Contract)
+        if isinstance(jsondict, dict) and "subtype" in jsondict:
+            if jsondict.get("resourceType") == "Contract":
+                value = jsondict.pop("subtype")
+
+                if value is not None:
+                    if isinstance(value, str):
+                        jsondict["subType"] = [{"text": value}]
+                    else:
+                        jsondict["subType"] = value
+
         # loop all registered properties and instantiate
         errs = []
         valid = set(['resourceType'])   # used to also contain `fhir_comments` until STU-3

--- a/test_issue.py
+++ b/test_issue.py
@@ -1,0 +1,9 @@
+from fhirclient.models.contract import Contract
+
+data = {
+    "resourceType": "Contract",
+    "subtype": "wrong"
+}
+
+contract = Contract(data)
+print(contract)

--- a/tests/test_contract_subtype.py
+++ b/tests/test_contract_subtype.py
@@ -1,0 +1,10 @@
+def test_subtype_alias():
+    from fhirclient.models.contract import Contract
+
+    data = {
+        "resourceType": "Contract",
+        "subtype": "example"
+    }
+
+    contract = Contract(data)
+    assert contract is not None


### PR DESCRIPTION
This PR fixes issue #202 by handling incorrectly labeled "subtype" field
returned by some DSTU2 APIs.

Changes:
- Maps "subtype" → "subType" only for Contract resource
- Normalizes string values into valid FHIR CodeableConcept structure
- Ensures compatibility with non-compliant FHIR implementations
- Does not affect other resources

All tests pass successfully.