### PR TITLE
fix: allow search parameter names in FHIRSearch.include() (#140)

### DIFF
--- a/fhir-parser-resources/fhirsearch.py
+++ b/fhir-parser-resources/fhirsearch.py
@@ -96,7 +96,8 @@ class FHIRSearch(object):
             in reference_model().elementProperties()
         }
 
-        if model_fields.get(reference_field) is not fhirreference.FHIRReference:
+        field_type = model_fields.get(reference_field)
+        if field_type is not None and field_type is not fhirreference.FHIRReference:
             logging.warning(
                 '%s does not have a reference type element named %s',
                 reference_model.resource_type, reference_field

--- a/fhirclient/models/fhirsearch.py
+++ b/fhirclient/models/fhirsearch.py
@@ -104,7 +104,8 @@ class FHIRSearch(object):
             in reference_model().elementProperties()
         }
 
-        if model_fields.get(reference_field) is not fhirreference.FHIRReference:
+        field_type = model_fields.get(reference_field)
+        if field_type is not None and field_type is not fhirreference.FHIRReference:
             logging.warning(
                 '%s does not have a reference type element named %s',
                 reference_model.resource_type, reference_field


### PR DESCRIPTION
## Summary

Fix `FHIRSearch.include()` rejecting valid search parameter names that don't match element names directly.

**Problem:** The `include()` method checks if `reference_field` exists as a direct field of type `FHIRReference` on the model. But FHIR search parameters (used in `_include`) often map to elements with different names. For example, `Task.subject` is a search parameter that maps to `Task.for`, but the model has no field literally named `subject` — it's stored as `for_fhir`.

This caused `FHIRSearch(Task).include('subject')` to silently drop the include with a misleading warning, even though `Task:subject` is a valid FHIR `_include` parameter.

**Fix:** Only reject the include when the field IS found in the model's properties but is not a `FHIRReference` type. When the field is not found at all, allow it through — it may be a valid search parameter name that maps to a differently-named element.

**Before:** `model_fields.get(reference_field) is not FHIRReference` → rejects when field doesn't exist (returns `None`)
**After:** `field_type is not None and field_type is not FHIRReference` → only rejects when field exists and is wrong type

Applied to both `fhirclient/models/fhirsearch.py` (runtime) and `fhir-parser-resources/fhirsearch.py` (generator template).

Fixes #140

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-v2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
