### PR TITLE
fix: allow list of (key, value) pairs in FHIRSearch for duplicate params

### DIFF
--- a/fhirclient/models/fhirsearch.py
+++ b/fhirclient/models/fhirsearch.py
@@ -42,11 +42,17 @@ class FHIRSearch(object):
         """ Used internally; stores list of included resources for the search. """
         
         if struct is not None:
-            if dict != type(struct):
-                raise Exception("Must pass a Python dictionary, but got a {}".format(type(struct)))
             self.wants_expand = True
-            for key, val in struct.items():
-                self.params.append(FHIRSearchParam(key, val))
+            if isinstance(struct, list):
+                for item in struct:
+                    if not (isinstance(item, (list, tuple)) and len(item) == 2):
+                        raise Exception("List items must be (key, value) pairs, but got {}".format(type(item)))
+                    self.params.append(FHIRSearchParam(item[0], item[1]))
+            elif dict == type(struct):
+                for key, val in struct.items():
+                    self.params.append(FHIRSearchParam(key, val))
+            else:
+                raise Exception("Must pass a Python dictionary or list of (key, value) pairs, but got a {}".format(type(struct)))
     
     
     # MARK: Execution

--- a/tests/fhirsearch_test.py
+++ b/tests/fhirsearch_test.py
@@ -1,0 +1,63 @@
+import pytest
+from fhirclient.models.fhirsearch import FHIRSearch, FHIRSearchParam
+from fhirclient.models.bundle import Bundle
+
+
+class TestFHIRSearchDuplicateParams:
+    """Tests for duplicate search parameter support via list-of-tuples input."""
+
+    def test_dict_struct_still_works(self):
+        """Existing dict-based usage must not regress."""
+        s = FHIRSearch(Bundle, {"_count": "10"})
+        url = s.construct()
+        assert "_count=10" in url
+
+    def test_list_of_tuples_single_param(self):
+        """List of tuples with a single entry produces the same URL as a dict."""
+        s = FHIRSearch(Bundle, [("_count", "10")])
+        url = s.construct()
+        assert "_count=10" in url
+
+    def test_list_of_tuples_duplicate_param(self):
+        """Two entries with the same key both appear in the constructed URL.
+
+        This is the core bug: a dict collapses the second 'date' key, so the
+        URL only carries one date constraint.  A list of tuples preserves both.
+        """
+        s = FHIRSearch(Bundle, [
+            ("date", {"$gt": "2018-05-21"}),
+            ("date", {"$lt": "2018-05-24"}),
+        ])
+        url = s.construct()
+        # Both constraints must be present as separate parameters
+        params = url.split("?", 1)[1].split("&")
+        date_params = [p for p in params if p.startswith("date=")]
+        assert len(date_params) == 2, (
+            f"Expected 2 date params, got {len(date_params)}: {params}"
+        )
+
+    def test_list_of_tuples_mixed_keys(self):
+        """Mixed keys work the same as a dict."""
+        s = FHIRSearch(Bundle, [("_count", "5"), ("status", "active")])
+        url = s.construct()
+        assert "_count=5" in url
+        assert "status=active" in url
+
+    def test_list_of_tuples_invalid_item_raises(self):
+        """A list with non-pair items raises a clear exception."""
+        with pytest.raises(Exception, match="key, value"):
+            FHIRSearch(Bundle, ["not-a-pair"])
+
+    def test_wrong_type_raises(self):
+        """Passing something other than dict or list raises."""
+        with pytest.raises(Exception):
+            FHIRSearch(Bundle, "bad")
+
+    def test_dict_cannot_express_duplicate_keys(self):
+        """Confirm the dict path only produces one date param (documents the limitation)."""
+        # Python silently drops duplicate dict keys at parse time; this verifies
+        # that the dict path isn't somehow producing duplicates itself.
+        s = FHIRSearch(Bundle, {"_count": "10", "status": "active"})
+        url = s.construct()
+        params = url.split("?", 1)[1].split("&")
+        assert len(params) == 2


### PR DESCRIPTION
## Problem

`FHIRSearch.__init__` requires `struct` to be a `dict`, which makes it impossible to express searches where the same parameter appears more than once. Python silently drops duplicate dict keys at parse time, so this is a silent data-loss bug rather than an obvious error.

A common real-world example — a bounded date range:

```
?date=gt2018-05-21&date=lt2018-05-24
```

There is no way to express this with the existing dict-only API. Reported in #64.

## Fix

Also accept a **list of `(key, value)` pairs** as `struct`. The list path uses the same `FHIRSearchParam` + `wants_expand` machinery already used for dicts, so all existing operator/modifier handlers work transparently.

```python
# before (only option — can't repeat 'date')
FHIRSearch(MedicationDispense, {'date': {'$gt': '2018-05-21'}})

# after — duplicate params now expressible
FHIRSearch(MedicationDispense, [
    ('date', {'$gt': '2018-05-21'}),
    ('date', {'$lt': '2018-05-24'}),
])
```

Existing dict usage is fully unchanged.

## Tests

- `test_list_of_tuples_duplicate_param` — the core regression: confirms two `date=` entries appear in the constructed URL
- `test_list_of_tuples_single_param` / `test_list_of_tuples_mixed_keys` — list path parity with dict path
- `test_list_of_tuples_invalid_item_raises` / `test_wrong_type_raises` — error handling
- `test_dict_struct_still_works` — no regression on existing dict path

All 19 tests pass (`tests/fhirsearch_test.py` + existing `fhirsearch_perform_iter_test.py` + `fhirreference_test.py`).

Fixes #64

---
_AI-assisted, human-reviewed._